### PR TITLE
Added tabular output

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,17 +7,17 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"text/tabwriter"
 )
-
 
 type Coinsdata struct {
 	Data []Coins `json:"data"`
 }
 
 type Coins struct {
-	Name string 
-	Cmc_rank int 
-	Quote Quotes `json:"quote"`
+	Name     string
+	Cmc_rank int
+	Quote    Quotes `json:"quote"`
 }
 
 type Quotes struct {
@@ -29,7 +29,7 @@ type Prices struct {
 }
 
 func main() {
-	fetchData() 	
+	fetchData()
 }
 
 func fetchData() {
@@ -61,20 +61,18 @@ func fetchData() {
 	}
 
 	var coinsData Coinsdata
-	err = json.Unmarshal([]byte(respBody), &coinsData) 
+	err = json.Unmarshal([]byte(respBody), &coinsData)
 	if err != nil {
 		fmt.Printf("%T\n%s\n%#v\n", err, err, err)
 	}
 
-	fmt.Println(coinsData)
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintln(w, "Ranking\tName\tPrice\t")
 
-	for i := 0; i < len(coinsData.Data); i++ {
-        fmt.Println("Ranking: " , coinsData.Data[i].Cmc_rank)
-		fmt.Println("Name: " , coinsData.Data[i].Name)
-		fmt.Println("Price: " , coinsData.Data[i].Quote.USD.Price)
-
-    }
-
+	for _, data := range coinsData.Data {
+		fmt.Fprintf(w, "%d\t%s\t%f\t\n", data.Cmc_rank, data.Name, data.Quote.USD.Price)
+	}
 }
 
 func captureHeader() string {

--- a/main.go
+++ b/main.go
@@ -2,16 +2,19 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"text/tabwriter"
 )
 
 type Coinsdata struct {
 	Data []Coins `json:"data"`
+	list int
 }
 
 type Coins struct {
@@ -34,7 +37,6 @@ func main() {
 
 func fetchData() {
 	// Api authentication
-	cmkValue := captureHeader()
 	client := &http.Client{}
 	serverUrl := "https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest"
 	req, err := http.NewRequest("GET", serverUrl, nil)
@@ -43,8 +45,7 @@ func fetchData() {
 		os.Exit(1)
 	}
 
-	req.Header.Set("Accepts", "application/json")
-	req.Header.Add("X-CMC_PRO_API_KEY", cmkValue)
+	buildQuery(req)
 
 	resp, errClient := client.Do(req)
 
@@ -78,4 +79,21 @@ func fetchData() {
 func captureHeader() string {
 	cmk := os.Getenv("CMMKVALUE")
 	return cmk
+}
+
+func buildQuery(req *http.Request) {
+	cmkValue := captureHeader()
+
+	req.Header.Set("Accepts", "application/json")
+	req.Header.Add("X-CMC_PRO_API_KEY", cmkValue)
+
+	// Getting the data passed from the cli parameters
+	list := flag.Int("list", 20, "the number of coins to be listed")
+	flag.Parse()
+
+	test := strconv.Itoa(*list)
+
+	q := req.URL.Query()
+	q.Add("limit", test)
+	req.URL.RawQuery = q.Encode()
 }

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func fetchData() {
 		log.Print(err)
 		os.Exit(1)
 	}
-	
+
 	buildRequest(req)
 
 	resp, errClient := client.Do(req)
@@ -93,9 +93,9 @@ func buildRequest(req *http.Request) {
 	flag.Parse()
 
 	// Converting from *int to string in order to build query parameter
-	test := strconv.Itoa(*list)
+	coinsLimit := strconv.Itoa(*list)
 
 	q := req.URL.Query()
-	q.Add("limit", test)
+	q.Add("limit", coinsLimit)
 	req.URL.RawQuery = q.Encode()
 }

--- a/main.go
+++ b/main.go
@@ -36,16 +36,16 @@ func main() {
 }
 
 func fetchData() {
-	// Api authentication
 	client := &http.Client{}
+
 	serverUrl := "https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest"
 	req, err := http.NewRequest("GET", serverUrl, nil)
 	if err != nil {
 		log.Print(err)
 		os.Exit(1)
 	}
-
-	buildQuery(req)
+	
+	buildRequest(req)
 
 	resp, errClient := client.Do(req)
 
@@ -81,7 +81,8 @@ func captureHeader() string {
 	return cmk
 }
 
-func buildQuery(req *http.Request) {
+func buildRequest(req *http.Request) {
+	// Api authentication
 	cmkValue := captureHeader()
 
 	req.Header.Set("Accepts", "application/json")
@@ -91,6 +92,7 @@ func buildQuery(req *http.Request) {
 	list := flag.Int("list", 20, "the number of coins to be listed")
 	flag.Parse()
 
+	// Converting from *int to string in order to build query parameter
 	test := strconv.Itoa(*list)
 
 	q := req.URL.Query()


### PR DESCRIPTION
- Added tabluar output using [tabwriter](https://pkg.go.dev/text/tabwriter), which is the package in the standard library for this type of job.
- Also updated the `for` loop to the [range](https://gobyexample.com/range) one, which is the most used way to iterate with slices in go
- Added cli parameter in order to list coins,  e.g.: `go run .\main.go --list=50`, with default of 20